### PR TITLE
fix(spree_chimpy/lib/spree/chimpy/interface/spree_order_upserter): Ve…

### DIFF
--- a/lib/spree/chimpy/interface/spree_order_upserter.rb
+++ b/lib/spree/chimpy/interface/spree_order_upserter.rb
@@ -1,7 +1,7 @@
 module Spree::Chimpy
   module Interface
     class SpreeOrderUpserter
-      delegate :log, :store_api_call, to: Spree::Chimpy
+      delegate :log, :store_api_call, :get_campaign_by_id, to: Spree::Chimpy
 
       # This is a generic Upserter Class for Spree Orders
       #
@@ -80,8 +80,14 @@ module Spree::Chimpy
           }
         }
 
-        if source
-          data[:campaign_id] = source.campaign_id
+
+        if source && source.campaign_id
+          begin
+            get_campaign_by_id(source.campaign_id)
+            data[:campaign_id] = source.campaign_id
+          rescue Gibbon::MailChimpError => e
+            log "Campaign with id: #{source.campaign_id} doesn't exist."
+          end
         end
 
         data

--- a/lib/spree_chimpy.rb
+++ b/lib/spree_chimpy.rb
@@ -38,6 +38,10 @@ module Spree::Chimpy
     Spree::Chimpy.api.ecommerce.stores(Spree::Chimpy::Config.store_id)
   end
 
+  def get_campaign_by_id(campaign_id)
+    Spree::Chimpy.api.campaigns(campaign_id).retrieve
+  end
+
   def list
     require 'spree/chimpy/interface/list'
     @list ||= Interface::List.new(Config.list_name,


### PR DESCRIPTION
…rify that campaign id exists via API call, otherwise rescue.

https://trello.com/c/bNpeOiki/205-mailchimp-ecommerce-sync-appears-to-be-broken